### PR TITLE
feat(COK-657): Refactors item identification to use UUIDs

### DIFF
--- a/src/interface.vue
+++ b/src/interface.vue
@@ -108,19 +108,13 @@
 import {computed, ref, watch} from 'vue';
 import draggable from 'vuedraggable';
 
-// UUID v4 generator function with modern browser support
+// UUID v4 generator function using only crypto.randomUUID()
 function generateUUID() {
-  // Use crypto.randomUUID() in modern browsers, fallback for older ones
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
     return crypto.randomUUID();
   }
 
-  // Fallback for older browsers
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    const r = Math.random() * 16 | 0;
-    const v = c == 'x' ? r : (r & 0x3 | 0x8);
-    return v.toString(16);
-  });
+  throw new Error('crypto.randomUUID() is not supported in this browser. Please update to a modern browser.');
 }
 
 export default {


### PR DESCRIPTION
Migrates from `_id` to `id` for item identification to align with current standards and removes reliance on timestamp-based IDs.

This change improves the way items are identified and ensures consistent unique identification across the application.

A UUID v4 generator is added to handle generating item IDs. Existing timestamp-based IDs are replaced with UUIDs.